### PR TITLE
QAI-60578 : updated the osgi version in config.ini

### DIFF
--- a/build/talend.studio.tos.bd.product/config.ini
+++ b/build/talend.studio.tos.bd.product/config.ini
@@ -4,7 +4,7 @@ osgi.splashPath=platform:/base/plugins/${product.branding.platform}/
 talend.studio.version=${version.full}
 eclipse.product=${product.branding.id}
 #The following osgi.framework key is required for the p2 update feature not to override the osgi.bundles values.
-osgi.framework=file\:plugins/org.eclipse.osgi_3.10.1.v20140909-1633.jar
+osgi.framework=file\:plugins/org.eclipse.osgi_3.10.100.v20150521-1310.jar
 osgi.bundles=org.eclipse.equinox.common@2:start,org.eclipse.update.configurator@3:start,org.eclipse.equinox.ds@2:start,org.eclipse.core.runtime@start,org.talend.maven.resolver@start,org.ops4j.pax.url.mvn@start,org.talend.components.api.service@start
 osgi.bundles.defaultStartLevel=4
 osgi.bundlefile.limit=200

--- a/build/talend.studio.tos.di.product/config.ini
+++ b/build/talend.studio.tos.di.product/config.ini
@@ -4,7 +4,7 @@ osgi.splashPath=platform:/base/plugins/${product.branding.platform}/
 talend.studio.version=${version.full}
 eclipse.product=${product.branding.id}
 #The following osgi.framework key is required for the p2 update feature not to override the osgi.bundles values.
-osgi.framework=file\:plugins/org.eclipse.osgi_3.10.1.v20140909-1633.jar
+osgi.framework=file\:plugins/org.eclipse.osgi_3.10.100.v20150521-1310.jar
 osgi.bundles=org.eclipse.equinox.common@2:start,org.eclipse.update.configurator@3:start,org.eclipse.equinox.ds@2:start,org.eclipse.core.runtime@start,org.talend.maven.resolver@start,org.ops4j.pax.url.mvn@start,org.talend.components.api.service@start
 osgi.bundles.defaultStartLevel=4
 osgi.bundlefile.limit=200

--- a/build/talend.studio.tos.dq.product/config.ini
+++ b/build/talend.studio.tos.dq.product/config.ini
@@ -4,7 +4,7 @@ osgi.splashPath=platform:/base/plugins/${product.branding.platform}/
 talend.studio.version=${version.full}
 eclipse.product=${product.branding.id}
 #The following osgi.framework key is required for the p2 update feature not to override the osgi.bundles values.
-osgi.framework=file\:plugins/org.eclipse.osgi_3.10.1.v20140909-1633.jar
+osgi.framework=file\:plugins/org.eclipse.osgi_3.10.100.v20150521-1310.jar
 osgi.bundles=org.eclipse.equinox.common@2:start,org.eclipse.update.configurator@3:start,org.eclipse.equinox.ds@2:start,org.eclipse.core.runtime@start,org.talend.maven.resolver@start,org.ops4j.pax.url.mvn@start
 osgi.bundles.defaultStartLevel=4
 osgi.bundlefile.limit=200

--- a/build/talend.studio.tos.esb.product/config.ini
+++ b/build/talend.studio.tos.esb.product/config.ini
@@ -4,7 +4,7 @@ osgi.splashPath=platform:/base/plugins/${product.branding.platform}/
 talend.studio.version=${version.full}
 eclipse.product=${product.branding.id}
 #The following osgi.framework key is required for the p2 update feature not to override the osgi.bundles values.
-osgi.framework=file\:plugins/org.eclipse.osgi_3.10.1.v20140909-1633.jar
+osgi.framework=file\:plugins/org.eclipse.osgi_3.10.100.v20150521-1310.jar
 osgi.bundles=org.eclipse.equinox.common@2:start,org.eclipse.update.configurator@3:start,org.eclipse.equinox.ds@2:start,org.eclipse.core.runtime@start,org.talend.maven.resolver@start,org.ops4j.pax.url.mvn@start,org.talend.components.api.service@start
 osgi.bundles.defaultStartLevel=4
 osgi.bundlefile.limit=200

--- a/build/talend.studio.tos.mdm.product/config.ini
+++ b/build/talend.studio.tos.mdm.product/config.ini
@@ -4,7 +4,7 @@ osgi.splashPath=platform:/base/plugins/${product.branding.platform}/
 talend.studio.version=${version.full}
 eclipse.product=${product.branding.id}
 #The following osgi.framework key is required for the p2 update feature not to override the osgi.bundles values.
-osgi.framework=file\:plugins/org.eclipse.osgi_3.10.1.v20140909-1633.jar
+osgi.framework=file\:plugins/org.eclipse.osgi_3.10.100.v20150521-1310.jar
 osgi.bundles=org.eclipse.equinox.common@2:start,org.eclipse.update.configurator@3:start,org.eclipse.equinox.ds@2:start,org.eclipse.core.runtime@start,org.talend.maven.resolver@start,org.ops4j.pax.url.mvn@start,org.talend.components.api.service@start
 osgi.bundles.defaultStartLevel=4
 osgi.bundlefile.limit=200


### PR DESCRIPTION
The talend-eclipse-p2-repository artifact was updated on Nexus to provide this new version (3.10.100).

Parent pom.xml is already pointing to 6.3.0-SNAPSHOT version.