### PR TITLE
removing old org.talend.sdk.component.studio-integration dependency

### DIFF
--- a/build/dependencies.p2/dependencies.p2.tos/pom.xml
+++ b/build/dependencies.p2/dependencies.p2.tos/pom.xml
@@ -170,13 +170,6 @@
 		<!-- End added by TDM -->
 		<!-- ========================= -->
 		
-		<!-- TCOMP v1 -->		
-        <dependency>
-            <groupId>org.talend.sdk.component</groupId>
-            <artifactId>org.talend.sdk.component.studio-integration</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
-        </dependency>
-		
 		<!-- TCOMP v1 -->
 
 		<dependency>


### PR DESCRIPTION
Removing old tcompv1 dependency

IMPORTANT: requires https://github.com/Talend/tdi-studio-se/pull/2035