### PR TITLE
Fix TUP-24170 Set crypto-utils as bundle to make the master compile with daikon 0.31.10-SNAPSHOT

### DIFF
--- a/build/dependencies.p2/dependencies.p2.tos/pom.xml
+++ b/build/dependencies.p2/dependencies.p2.tos/pom.xml
@@ -88,6 +88,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.talend.daikon</groupId>
+			<artifactId>crypto-utils</artifactId>
+			<version>${daikon.version}</version>
+			<classifier>bundle</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.talend.daikon</groupId>
 			<artifactId>daikon-exception</artifactId>
 			<version>${daikon.version}</version>
 			<classifier>bundle</classifier>
@@ -128,6 +134,21 @@
 			<artifactId>jaxb-api</artifactId>
 			<version>2.3.1</version>
 		</dependency>
+		<dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.7</version>
+        </dependency>
         <!-- end of daikon dependencies -->
 
 		<!-- ========================= -->

--- a/build/dependencies.p2/dependencies.p2.tos/pom.xml
+++ b/build/dependencies.p2/dependencies.p2.tos/pom.xml
@@ -134,21 +134,6 @@
 			<artifactId>jaxb-api</artifactId>
 			<version>2.3.1</version>
 		</dependency>
-		<dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.9.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-configuration2</artifactId>
-            <version>2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.7</version>
-        </dependency>
         <!-- end of daikon dependencies -->
 
 		<!-- ========================= -->

--- a/build/dependencies.p2/dependencies.p2.tos/pom.xml
+++ b/build/dependencies.p2/dependencies.p2.tos/pom.xml
@@ -134,6 +134,21 @@
 			<artifactId>jaxb-api</artifactId>
 			<version>2.3.1</version>
 		</dependency>
+		<dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.7</version>
+        </dependency>
         <!-- end of daikon dependencies -->
 
 		<!-- ========================= -->

--- a/build/dependencies.p2/pom.xml
+++ b/build/dependencies.p2/pom.xml
@@ -10,7 +10,7 @@
         <components.version>0.28.0-SNAPSHOT</components.version>
         <dataquality.lib.version>7.2.0-SNAPSHOT</dataquality.lib.version>
         <fasterxml.jackson.version>2.9.9</fasterxml.jackson.version>
-        <daikon.version>0.31.8</daikon.version>
+        <daikon.version>0.31.10-SNAPSHOT</daikon.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Fix TUP-24170 Set crypto-utils as bundle to make the master compile with daikon 0.31.10-SNAPSHOT
https://jira.talendforge.org/browse/TUP-24170