### PR TITLE
chore: bump TCOMP components version to 0.37.0-SNAPSHOT

### DIFF
--- a/talend.studio.parent.pom/pom.xml
+++ b/talend.studio.parent.pom/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <components.version>0.36.0-SNAPSHOT</components.version>
+        <components.version>0.37.0-SNAPSHOT</components.version>
         <tacokit.components.version>1.26.0-SNAPSHOT</tacokit.components.version>
         <component-runtime.version>1.37.0</component-runtime.version>
         <m2.fasterxml.jackson.version>2.11.4</m2.fasterxml.jackson.version>


### PR DESCRIPTION
chore: bump TCOMP components version to 0.37.0-SNAPSHOT after tcompv0/0.36.0 release.